### PR TITLE
Install build-essential in CI

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            build-essential \
             debhelper \
             devscripts \
             dpkg-dev \

--- a/.github/workflows/publish-apt.yml
+++ b/.github/workflows/publish-apt.yml
@@ -40,6 +40,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             apt-utils \
+            build-essential \
             debhelper \
             devscripts \
             dpkg-dev \


### PR DESCRIPTION
Add build-essential to the package build and APT publish workflows so dpkg-buildpackage can satisfy its build dependencies on GitHub Actions runners.