### PR TITLE
Document Deb822 APT source setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,38 @@ cd mpwrd-menu
 chmod +x mpwrd-menu.sh
 ```
 
+## Debian Package
+
+Use this Deb822 source file for the published APT repo:
+
+```deb822
+Types: deb
+URIs: https://mpwrd-os.github.io/mpwrd-menu
+Suites: testing
+Components: main
+Architectures: all
+Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg
+```
+
+Install from the testing channel:
+
+```bash
+curl -fsSL https://mpwrd-os.github.io/mpwrd-menu/mpwrd-archive-keyring.gpg \
+  | sudo tee /usr/share/keyrings/mpwrd-archive-keyring.gpg > /dev/null
+
+sudo tee /etc/apt/sources.list.d/mpwrd-menu.sources > /dev/null <<'EOF'
+Types: deb
+URIs: https://mpwrd-os.github.io/mpwrd-menu
+Suites: testing
+Components: main
+Architectures: all
+Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg
+EOF
+
+sudo apt update
+sudo apt install mpwrd-menu
+```
+
 ## Run
 
 ```bash

--- a/packaging/pages/index.html
+++ b/packaging/pages/index.html
@@ -10,8 +10,18 @@
   <p>Public key:</p>
   <pre>curl -fsSL https://mpwrd-os.github.io/mpwrd-menu/mpwrd-archive-keyring.gpg | sudo tee /usr/share/keyrings/mpwrd-archive-keyring.gpg &gt; /dev/null</pre>
   <p>Stable channel:</p>
-  <pre>deb [signed-by=/usr/share/keyrings/mpwrd-archive-keyring.gpg] https://mpwrd-os.github.io/mpwrd-menu stable main</pre>
+  <pre>Types: deb
+URIs: https://mpwrd-os.github.io/mpwrd-menu
+Suites: stable
+Components: main
+Architectures: all
+Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg</pre>
   <p>Testing channel:</p>
-  <pre>deb [signed-by=/usr/share/keyrings/mpwrd-archive-keyring.gpg] https://mpwrd-os.github.io/mpwrd-menu testing main</pre>
+  <pre>Types: deb
+URIs: https://mpwrd-os.github.io/mpwrd-menu
+Suites: testing
+Components: main
+Architectures: all
+Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg</pre>
 </body>
 </html>


### PR DESCRIPTION
Update the README and published repository page snippets to use Deb822 source examples with Architectures: all so apt clients consume the Bash-only package repository without unnecessary architecture warnings.