### PR TITLE
Use Debian lintian profile in CI

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -46,7 +46,7 @@ jobs:
         run: ./packaging/build-deb.sh
 
       - name: Run lintian
-        run: lintian --fail-on error dist/*.changes
+        run: lintian --profile debian --fail-on error dist/*.changes
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Run lintian with the Debian profile in the package build workflow so Debian changelog distributions like unstable are evaluated correctly on Ubuntu GitHub runners.