### PR TITLE
Use /etc/apt/keyrings in APT setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ URIs: https://mpwrd-os.github.io/mpwrd-menu
 Suites: testing
 Components: main
 Architectures: all
-Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg
+Signed-By: /etc/apt/keyrings/mpwrd-archive-keyring.gpg
 ```
 
 Install from the testing channel:
 
 ```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+
 curl -fsSL https://mpwrd-os.github.io/mpwrd-menu/mpwrd-archive-keyring.gpg \
-  | sudo tee /usr/share/keyrings/mpwrd-archive-keyring.gpg > /dev/null
+  | sudo tee /etc/apt/keyrings/mpwrd-archive-keyring.gpg > /dev/null
 
 sudo tee /etc/apt/sources.list.d/mpwrd-menu.sources > /dev/null <<'EOF'
 Types: deb
@@ -52,7 +54,7 @@ URIs: https://mpwrd-os.github.io/mpwrd-menu
 Suites: testing
 Components: main
 Architectures: all
-Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg
+Signed-By: /etc/apt/keyrings/mpwrd-archive-keyring.gpg
 EOF
 
 sudo apt update

--- a/packaging/pages/index.html
+++ b/packaging/pages/index.html
@@ -8,20 +8,21 @@
 <body>
   <h1>mPWRD-OS APT Repository</h1>
   <p>Public key:</p>
-  <pre>curl -fsSL https://mpwrd-os.github.io/mpwrd-menu/mpwrd-archive-keyring.gpg | sudo tee /usr/share/keyrings/mpwrd-archive-keyring.gpg &gt; /dev/null</pre>
+  <pre>sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://mpwrd-os.github.io/mpwrd-menu/mpwrd-archive-keyring.gpg | sudo tee /etc/apt/keyrings/mpwrd-archive-keyring.gpg &gt; /dev/null</pre>
   <p>Stable channel:</p>
   <pre>Types: deb
 URIs: https://mpwrd-os.github.io/mpwrd-menu
 Suites: stable
 Components: main
 Architectures: all
-Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg</pre>
+Signed-By: /etc/apt/keyrings/mpwrd-archive-keyring.gpg</pre>
   <p>Testing channel:</p>
   <pre>Types: deb
 URIs: https://mpwrd-os.github.io/mpwrd-menu
 Suites: testing
 Components: main
 Architectures: all
-Signed-By: /usr/share/keyrings/mpwrd-archive-keyring.gpg</pre>
+Signed-By: /etc/apt/keyrings/mpwrd-archive-keyring.gpg</pre>
 </body>
 </html>


### PR DESCRIPTION
Update the README and published repository page to install the archive key under /etc/apt/keyrings and reference that path from Deb822 source examples so manual APT setup matches current Debian practice.