### PR TITLE
Add Cockpit to mesh apps

### DIFF
--- a/mesh-apps.conf
+++ b/mesh-apps.conf
@@ -2,6 +2,7 @@
 # manager values: apt, pipx, or pipx-global
 
 Contact|pipx|contact
+Cockpit|apt|cockpit cockpit-networkmanager
 Meshtastic CLI|pipx-global|meshtastic
 
 # Example apt entry:


### PR DESCRIPTION
Add a Cockpit app entry to the mesh apps registry so the menu can install both cockpit and cockpit-networkmanager through apt.