### PR TITLE
Add Mosquitto to mesh apps

### DIFF
--- a/mesh-apps.conf
+++ b/mesh-apps.conf
@@ -4,6 +4,7 @@
 Contact|pipx|contact
 Cockpit|apt|cockpit cockpit-networkmanager
 Meshtastic CLI|pipx-global|meshtastic
+Mosquitto|apt|mosquitto
 
 # Example apt entry:
 # Example App|apt|example-package


### PR DESCRIPTION
Add a Mosquitto app entry to the mesh apps registry so the menu can install the mosquitto package through apt.