### PR TITLE
Debian: Add recommends / depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lightweight TUI for mPWRD-OS.
 
 ## Overview
 
-`mpwrd-menu` is a dependency-free Bash menu for minimal console images. It provides:
+`mpwrd-menu` is a lightweight Bash menu for minimal console images. It provides:
 
 - `Contact`
 - `Meshtastic Related Services`

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,14 @@ Homepage: https://github.com/mPWRD-OS/mpwrd-menu
 
 Package: mpwrd-menu
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends},
+         sudo,
+         bash,
+         gpg,
+         curl,
+         wget,
+         pipx
 Description: Bash TUI for Meshtastic tasks on mPWRD-OS
- A dependency-free terminal menu for mPWRD-OS images that provides
+ A lightweight terminal menu for mPWRD-OS images that provides
  quick access to Meshtastic services, package actions, network setup,
  and board configuration tasks.


### PR DESCRIPTION
These deps already exist in mPWRD-OS, but should make it a bit easier to test in minimal containers.