### PR TITLE
Remove pipx temp directory fallback

### DIFF
--- a/mpwrd-menu
+++ b/mpwrd-menu
@@ -8,7 +8,6 @@ readonly SERVICE_REGISTRY="${SERVICE_REGISTRY:-/usr/share/mpwrd-menu/mesh-servic
 readonly MESHTASTIC_PACKAGE="meshtasticd"
 readonly MESHTASTIC_DEBIAN_SERIES="Debian_13"
 readonly REPO_CHANNELS=("beta" "alpha" "daily")
-readonly PIPX_TMP_THRESHOLD_KB=65536
 readonly AVAILABLE_CONFIG_DIR="/etc/meshtasticd/available.d"
 readonly ACTIVE_CONFIG_DIR="/etc/meshtasticd/config.d"
 
@@ -552,7 +551,7 @@ manage_app_action() {
         return 1
       fi
 
-      run_and_pause "${verb} ${label}..." run_pipx_action "$action" "$package" user
+      run_and_pause "${verb} ${label}..." pipx "$action" "$package"
       ;;
     pipx-global)
       if ! command_exists pipx; then
@@ -642,52 +641,7 @@ run_pipx_global_action() {
   local action="$1"
   local package="$2"
 
-  run_pipx_action "$action" "$package" root
-}
-
-tmp_free_kb() {
-  local path="$1"
-  df -Pk "$path" 2>/dev/null | awk 'NR == 2 { print $4 }'
-}
-
-run_pipx_action() {
-  local action="$1"
-  local package="$2"
-  local scope="${3:-user}"
-  local free_kb=""
-  local temp_dir=""
-  local rc=0
-
-  free_kb="$(tmp_free_kb /tmp)"
-  if [[ -n "$free_kb" && "$free_kb" =~ ^[0-9]+$ && "$free_kb" -lt "$PIPX_TMP_THRESHOLD_KB" ]]; then
-    temp_dir="$(mktemp -d /var/tmp/mpwrd-menu-pipx.XXXXXX)"
-  fi
-
-  if [[ "$scope" == "root" ]]; then
-    if [[ -n "$temp_dir" ]]; then
-      as_root env \
-        TMPDIR="$temp_dir" \
-        pipx "$action" --global "$package"
-      rc=$?
-    else
-      as_root pipx "$action" --global "$package"
-      rc=$?
-    fi
-  else
-    if [[ -n "$temp_dir" ]]; then
-      env TMPDIR="$temp_dir" pipx "$action" "$package"
-      rc=$?
-    else
-      pipx "$action" "$package"
-      rc=$?
-    fi
-  fi
-
-  if [[ -n "$temp_dir" ]]; then
-    rm -rf "$temp_dir"
-  fi
-
-  return "$rc"
+  as_root pipx "$action" --global "$package"
 }
 
 indexed_list_menu() {


### PR DESCRIPTION
Drop the /tmp space check and /var/tmp TMPDIR workaround from mpwrd-menu so pipx actions use their normal user and global execution paths again.