### PR TITLE
Debian: Add yq dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Depends: ${misc:Depends},
          gpg,
          curl,
          wget,
-         pipx
+         pipx,
+         yq
 Description: Bash TUI for Meshtastic tasks on mPWRD-OS
  A lightweight terminal menu for mPWRD-OS images that provides
  quick access to Meshtastic services, package actions, network setup,


### PR DESCRIPTION
Add dependency on `yq`. Pre-req to support https://github.com/meshtastic/firmware/pull/10001