### PR TITLE
Show mPWRD-OS version in main menu

### DIFF
--- a/mpwrd-menu
+++ b/mpwrd-menu
@@ -7,6 +7,7 @@ readonly APP_REGISTRY="${APP_REGISTRY:-/usr/share/mpwrd-menu/mesh-apps.conf}"
 readonly SERVICE_REGISTRY="${SERVICE_REGISTRY:-/usr/share/mpwrd-menu/mesh-services.conf}"
 readonly MESHTASTIC_PACKAGE="meshtasticd"
 readonly MESHTASTIC_DEBIAN_SERIES="Debian_13"
+readonly MPWRD_RELEASE_FILE="/etc/mPWRD-release"
 readonly REPO_CHANNELS=("beta" "alpha" "daily")
 readonly AVAILABLE_CONFIG_DIR="/etc/meshtasticd/available.d"
 readonly ACTIVE_CONFIG_DIR="/etc/meshtasticd/config.d"
@@ -93,6 +94,22 @@ trim() {
   printf '%s' "$value"
 }
 
+mpwrd_os_version() {
+  local version=""
+
+  if [[ ! -r "$MPWRD_RELEASE_FILE" ]]; then
+    return 1
+  fi
+
+  IFS= read -r version < "$MPWRD_RELEASE_FILE" || true
+  version="$(trim "$version")"
+  if [[ -z "$version" ]]; then
+    return 1
+  fi
+
+  printf '%s' "$version"
+}
+
 read_key() {
   local key extra
   IFS= read -rsn1 key || {
@@ -134,6 +151,7 @@ render_menu() {
   local end=0
   local i=0
   local page_size=0
+  local release_version=""
   local start=0
 
   count="${#options_ref[@]}"
@@ -158,6 +176,9 @@ render_menu() {
 
   clear_screen
   printf 'mPWRD-menu\n'
+  if [[ "$title" == "Main Menu" ]] && release_version="$(mpwrd_os_version)"; then
+    printf 'mPWRD-OS v%s\n' "$release_version"
+  fi
   printf '============\n\n'
   printf '%s\n' "$title"
   printf '%s\n\n' "$prompt"


### PR DESCRIPTION
## Summary

Show the mPWRD-OS version under the main menu title when `/etc/mPWRD-release` exists and contains a version.

## Changes

- add a small helper to read `/etc/mPWRD-release`
- show `mPWRD-OS v<version>` in the main menu header only when the file is present and non-empty
- leave the header unchanged on systems where the file does not exist

## Validation

- `bash -n mpwrd-menu`
