### PR TITLE
Speed up suggested board config matching

### DIFF
--- a/mpwrd-menu
+++ b/mpwrd-menu
@@ -1624,6 +1624,83 @@ enable_i2c_overlay() {
   fi
 }
 
+board_config_name_if_compatible() {
+  local file="$1"
+  local query="$2"
+
+  awk -v query="$query" '
+    BEGIN {
+      in_meta = 0
+      in_compatible = 0
+      matched = 0
+      name = ""
+    }
+
+    /^[[:space:]]*#/ { next }
+
+    /^[^[:space:]#][^:]*:[[:space:]]*$/ {
+      if ($0 == "Meta:") {
+        in_meta = 1
+        in_compatible = 0
+        next
+      }
+      if (in_meta) {
+        in_meta = 0
+        in_compatible = 0
+      }
+    }
+
+    !in_meta { next }
+
+    /^  name:[[:space:]]*/ {
+      name = $0
+      sub(/^  name:[[:space:]]*/, "", name)
+      gsub(/[[:space:]]+$/, "", name)
+      next
+    }
+
+    /^  compatible:[[:space:]]*$/ {
+      in_compatible = 1
+      next
+    }
+
+    in_compatible && /^    -[[:space:]]*/ {
+      value = $0
+      sub(/^    -[[:space:]]*/, "", value)
+      sub(/[[:space:]]*#.*/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (value == query) {
+        matched = 1
+      }
+      next
+    }
+
+    in_compatible {
+      in_compatible = 0
+    }
+
+    END {
+      if (matched) {
+        printf("%s\n", name)
+      }
+    }
+  ' "$file"
+}
+
+board_config_query_alias() {
+  case "$1" in
+    rpi4b)
+      printf 'raspberry-pi'
+      ;;
+    luckfox-lyra-zero-deck)
+      printf 'luckfox-lyra-zero-w'
+      ;;
+    *)
+      printf '%s' "$1"
+      ;;
+  esac
+}
+
 find_compatible_configs() {
   local directory="$1"
   local query="$2"
@@ -1639,17 +1716,17 @@ find_compatible_configs() {
   [[ -d "$directory" && -n "$query" ]] || return 0
 
   while IFS= read -r file; do
-    if yq -e --arg q "$query" '.Meta.compatible[] | select(. == $q)' "$file" >/dev/null 2>&1; then
-      relative_path="${file#"$directory/"}"
-      name="$(yq -r '.Meta.name // ""' "$file" 2>/dev/null)"
-      result_files_ref+=("$relative_path")
-      if [[ -n "$name" ]]; then
-        result_labels_ref+=("$name [$relative_path]")
-      else
-        result_labels_ref+=("$relative_path")
-      fi
+    name="$(board_config_name_if_compatible "$file" "$query")"
+    [[ -n "$name" ]] || continue
+
+    relative_path="${file#"$directory/"}"
+    result_files_ref+=("$relative_path")
+    if [[ -n "$name" ]]; then
+      result_labels_ref+=("$name [$relative_path]")
+    else
+      result_labels_ref+=("$relative_path")
     fi
-  done < <(find "$directory" -mindepth 1 -type f 2>/dev/null | sort)
+  done < <(find "$directory" -mindepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | sort)
 }
 
 default_board_config_query() {
@@ -1660,11 +1737,8 @@ default_board_config_query() {
     "")
       printf ''
       ;;
-    rpi4b)
-      printf 'raspberry-pi'
-      ;;
     *)
-      printf '%s' "$board_value"
+      board_config_query_alias "$board_value"
       ;;
   esac
 }
@@ -1676,11 +1750,6 @@ apply_suggested_board_config_menu() {
   local options=()
 
   query="$(default_board_config_query)"
-
-  if ! command_exists yq; then
-    message_box 'yq is required for suggested board config matching. Use Browse all configs instead.'
-    return 1
-  fi
 
   if [[ -z "$query" ]]; then
     message_box 'Could not detect the current board. Use Browse all configs instead.'

--- a/mpwrd-menu
+++ b/mpwrd-menu
@@ -14,6 +14,8 @@ readonly REPO_CHANNELS=("beta" "alpha" "daily")
 readonly AVAILABLE_CONFIG_DIR="/etc/meshtasticd/available.d"
 readonly ACTIVE_CONFIG_DIR="/etc/meshtasticd/config.d"
 readonly ARMBIAN_ENV_FILE="${ARMBIAN_ENV_FILE:-/boot/armbianEnv.txt}"
+readonly COLOR_RESET=$'\033[0m'
+readonly COLOR_YELLOW=$'\033[33m'
 
 MENU_RESULT=-1
 READ_KEY=""
@@ -137,6 +139,25 @@ mpwrd_menu_version() {
   printf '%s' "$version"
 }
 
+board_not_configured() {
+  local first_entry=""
+
+  IFS= read -r first_entry < <(find "$ACTIVE_CONFIG_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)
+  if [[ -n "$first_entry" ]]; then
+    return 1
+  fi
+
+  if [[ -d /proc/device-tree/hat ]]; then
+    return 1
+  fi
+
+  if command_exists lsusb && lsusb -d 1a86:5512 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  return 0
+}
+
 print_version_info() {
   local menu_version=""
   local os_version=""
@@ -199,6 +220,8 @@ render_menu() {
   local page_size=0
   local release_version=""
   local start=0
+  local option_display=""
+  local warn_unconfigured=0
 
   count="${#options_ref[@]}"
   page_size="$(menu_window_size)"
@@ -228,6 +251,10 @@ render_menu() {
   if [[ "$title" == "Main Menu" ]] && release_version="$(mpwrd_os_version)"; then
     printf 'mPWRD-OS v%s\n' "$release_version"
   fi
+  if [[ "$title" == "Main Menu" ]] && board_not_configured; then
+    printf '%b\n' "${COLOR_YELLOW}BOARD NOT CONFIGURED${COLOR_RESET}"
+    warn_unconfigured=1
+  fi
   printf '============\n\n'
   printf '%s\n' "$title"
   printf '%s\n\n' "$prompt"
@@ -237,10 +264,14 @@ render_menu() {
   fi
 
   for (( i = start; i < end; i++ )); do
+    option_display="${options_ref[$i]}"
+    if (( warn_unconfigured )) && [[ "$option_display" == "Board Config" ]]; then
+      option_display="${COLOR_YELLOW}BOARD CONFIG${COLOR_RESET}"
+    fi
     if (( i == selected )); then
-      printf ' > %s\n' "${options_ref[$i]}"
+      printf ' > %b\n' "$option_display"
     else
-      printf '   %s\n' "${options_ref[$i]}"
+      printf '   %b\n' "$option_display"
     fi
   done
 
@@ -392,7 +423,9 @@ apt_package_action() {
 install_board_config_file() {
   local source_file="$1"
   local target_file="$2"
-  as_root mkdir -p "$ACTIVE_CONFIG_DIR" && as_root install -m 0644 "$source_file" "$target_file"
+  as_root mkdir -p "$ACTIVE_CONFIG_DIR" &&
+    as_root install -m 0644 "$source_file" "$target_file" &&
+    as_root systemctl restart "$MESHTASTIC_PACKAGE"
 }
 
 reset_array() {

--- a/mpwrd-menu
+++ b/mpwrd-menu
@@ -1766,7 +1766,7 @@ apply_suggested_board_config_menu() {
   options=("${config_labels[@]}" "Back")
 
   while true; do
-    menu_choose 'Apply Suggested Config' "Detected board: $query" options || return 0
+    menu_choose 'Select Radio Configuration' "Detected board: $query" options || return 0
     if (( MENU_RESULT == ${#config_files[@]} )); then
       return 0
     fi
@@ -1778,7 +1778,7 @@ apply_suggested_board_config_menu() {
 
 board_config_menu() {
   local options=(
-    "Apply suggested config"
+    "Select radio configuration"
     "Browse all configs"
     "Remove active config"
     "Edit Current Config"


### PR DESCRIPTION
Replace the per-file yq lookup with a shell-native awk matcher over YAML config files

Limit the scan to yaml files and remove the hard dependency on yq for suggested board config selection

Normalize board IDs where needed so suggested configs match existing compatible entries